### PR TITLE
Fixed release build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build wheels
-        run: docker run --rm --entrypoint bash -v $(pwd):/io konstin2/maturin:v0.12.10 ./packaging/build_many.sh
+        run: docker run --rm --entrypoint bash -v $(pwd):/io ghcr.io/pyo3/maturin ./packaging/build_many.sh
       - name: Archive wheels
         uses: actions/upload-artifact@v2
         with:

--- a/packaging/build_many.sh
+++ b/packaging/build_many.sh
@@ -1,3 +1,3 @@
 set -x
 yum install -y unixODBC
-maturin build --strip --release --manylinux 2010
+maturin build --strip --release --manylinux 2014


### PR DESCRIPTION
Hello, 

I saw the build release is broken. I tried to fix it but I can't build because maturin 2010 doesn't support aarch64 (I only have aarch64 env).
So I have to migrate to maturin 2014 and it works. 
<img width="910" alt="Capture d’écran 2022-12-06 à 14 26 16" src="https://user-images.githubusercontent.com/798369/205926162-cafe8242-2983-4a72-a6c0-48f7c8862f4a.png">



